### PR TITLE
fix CITMIC.R/line 129: lnscore filtering by cell type

### DIFF
--- a/R/CITMIC.R
+++ b/R/CITMIC.R
@@ -126,7 +126,7 @@ CITMIC<-function(GEP,weighted = TRUE,base = 10,damping=0.90,cl.cores=1,cell.type
   if(is.null(cell.type)){
     lnscore<-lnscore
   }else{
-    lnscore[cell.type,]
+    lnscore<-lnscore[cell.type,]
   }
   return(lnscore)
 }


### PR DESCRIPTION
[CITMIC.R/line 129: ](https://github.com/zhaopapers/CITMIC/blob/9eecc16d5c9e7b51fb88ea622c3d25e9ed4821aa/R/CITMIC.R#L129)

`lnscore[cell.type,]` will return the filtered matrix to the stdr output.

Assigning it to `lnscore <- lnscore[cell.type,]` will return the intended result.